### PR TITLE
Install Or Update Dependabot to support Docker and Gomods

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Golang builder image
 FROM golang:1.20.4 as builder2
 
-# Base image
+# Base image to update
 FROM gcr.io/k8s-staging-build-image/debian-base-amd64:buster-v1.3.0
 


### PR DESCRIPTION

Enable Dependabot for Dockerfile and go.mod updates.
This will update images in Dockerfile `FROM` statements, and go modules.

This PR is created by a script. Please let me know if we should modify any values.
